### PR TITLE
Add typescript typings

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,43 @@
+import {Request} from 'express';
+import * as passport from 'passport';
+
+export interface StrategyOptions {
+  clientID: string;
+  clientSecret: string;
+  callbackURL: string;
+  passReqToCallback?: true;
+  scope?: string[];
+}
+
+export interface StrategyOptionsWithRequest {
+  clientID: string;
+  clientSecret: string;
+  callbackURL: string;
+  passReqToCallback: true;
+  scope?: string[];
+}
+
+export interface VerifyOptions {
+  message: string;
+}
+
+export interface VerifyCallback {
+  (error: any, user?: any, options?: VerifyOptions): void;
+}
+
+export interface VerifyFunctionWithRequest {
+  (req: Request, accessToken: string, refreshToken: string, profile: any, done: VerifyCallback): void;
+}
+
+export interface VerifyFunction {
+  (accessToken: string, refreshToken: string, profile: any, done: VerifyCallback): void;
+}
+
+declare class Strategy implements Strategy {
+  public name: string;
+  public authenticate: (req: Request, options?: object) => void;
+
+  constructor(options: StrategyOptionsWithRequest, verify: VerifyFunctionWithRequest);
+  constructor(options: StrategyOptions, verify: VerifyFunction);
+  constructor(verify: VerifyFunction);
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.6",
   "description": "Passport strategy for Google OAuth 2.0",
   "main": "./lib/oauth2.js",
+  "typings": "lib/index",
   "directories": {
     "example": "examples",
     "test": "test"


### PR DESCRIPTION
I've just started a new TypeScript project and I wanted to pull in this module but sadly there were no typings in here or in the [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) project.

The typings I've added cover the full external interface of the module making it easy to use, by hooking it into the package.json it means it's usable with just a simple `npm install...` without having to do any additional work. Hopefully this will help make your module more accessible to TS users :)

Love the module by the way, it's been a pleasure to use!

